### PR TITLE
Fix issue when exporting .xnb files

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,4 +1,4 @@
 python -m build --wheel
 python setup.py bdist_wheel
 
-pip install .\dist\deppth2-0.1.6.0-py3-none-any.whl
+pip install .\dist\deppth2-0.1.6.1-py3-none-any.whl

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ To install Deppth2, `pip install deppth2` or download the latest [wheel](https:/
 
 ### Dependencies
 
-Deppth2 technically has no required dependencies outside of Python's core modules, but you may find its functionality very limited without also installing the following optional dependencies. If an optional dependency is missing, Deppth2 will abort an operation dependent on that module informing you of the missing module.
+Deppth2 technically has two required dependencies, `pillow` and `lz4`, as they are the primary tools that deppth2 uses. If an optional dependency is missing, Deppth2 will abort an operation dependent on that module informing you of the missing module.
 
-Packages primarily contain sprite sheets. Deppth2 uses Pillow to work with the image data within. If you plan to export/import sprite sheets to/from image files, you'll need to install that: `pip install pillow`.
-
-Hades uses LZ4 compression on its packages. If you plan to work with these packages, you'll want to install the LZ4 module: `pip install lz4`.
+> As packages primarily contain sprite sheets, deppth2 uses Pillow to work with the image data within. <br>
+> Hades/Hades 2 uses LZ4 compression on its packages, and as such, lz4 is automatically installed to allow for deppth2 to work with Hades/Hades 2.
 
 Transistor and Pyre both use LZF compression on their packages. If you plan to work with these packages, you'll want to install the LZF module: `pip install lzf`. You may need to install C++ build tools to get this dependency to install correctly.
 

--- a/deppth2/deppth2.py
+++ b/deppth2/deppth2.py
@@ -1,6 +1,6 @@
 """Top-level API exposure of package actions"""
 
-__version__ = "0.1.6.0"
+__version__ = "0.1.6.1"
 
 import os
 import sys

--- a/deppth2/entries.py
+++ b/deppth2/entries.py
@@ -212,6 +212,8 @@ class XNBAssetEntryBase(EntryBase):
   def _export(self, path):
     if os.path.splitext(path)[1] != '.xnb':
       return super()._export(path)
+    
+    os.makedirs(os.path.dirname(path), exist_ok=True)
 
     with open(path, 'wb') as f:
       f.write(self.data)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         },
     version = version,
     include_package_data=True,
+    install_requires=['pillow', 'lz4'],
     package_data={
         "deppth2": ["texconv/texconv.exe"]
     },


### PR DESCRIPTION
Getting this issue when extracting Fx.pkg `FileNotFoundError: [Errno 2] No such file or directory: 'Fx\\textures\\3d\\AlectoRage.xnb'`, which causes the rest of the extraction to halt.
PR allows for the files to be created - although we can't do anything with xnb files - it now won't throw errors.
