### PR TITLE
Fixed hulls dictionary in manifest

### DIFF
--- a/deppth2/texpacking.py
+++ b/deppth2/texpacking.py
@@ -202,7 +202,7 @@ def transform_hull(hull, topLeft, size):
     def transform_point(point):
         x = point[0] - topLeft['x'] - round(size[0]/2.0)
         y = point[1] - topLeft['y'] - round(size[1]/2.0)
-        return [x, y]
+        return {'x': x, 'y': y}
 
     new_hull = []
     for point in hull:


### PR DESCRIPTION
The current version might not actually break anything, but this change aligns the layout of the hulls dict to what the "base game" manifests look like.