### PR TITLE
Moved imports to funcs, fix issue with same name images in different folders being overwritten

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,4 +1,14 @@
-python -m build --wheel
-python setup.py bdist_wheel
+Open CMD\
+pip install build if you don't have it\
+> pip install --upgrade build
 
-pip install .\dist\deppth2-0.1.6.3-py3-none-any.whl
+Build the Wheel\
+> python -m build --wheel
+
+Install the Wheel\
+> pip install .\dist\deppth2-0.1.6.3-py3-none-any.whl\
+Wildcard:
+> pip install .\dist\deppth2*.whl
+
+Delete dist, build wheel, install wheel\
+> del .\dist\deppth2* && python -m build --wheel && for %i in (.\dist\deppth2*.whl) do pip install "%i" --force-reinstall

--- a/deppth2/deppth2.py
+++ b/deppth2/deppth2.py
@@ -1,6 +1,6 @@
 """Top-level API exposure of package actions"""
 
-__version__ = "0.1.6.3"
+__version__ = "0.1.6.4"
 
 import os
 import sys


### PR DESCRIPTION
Moved imports around to the funcs that need them
Fixed issue where if you had multiple images in different folders with the same name, they wouldn't get created properly due to pytexturepacker overwriting