### PR TITLE
Add subtexture manifests and proper scaling support while packing textures

### DIFF
--- a/deppth2/entries.py
+++ b/deppth2/entries.py
@@ -380,6 +380,11 @@ class TextureEntry(XNBAssetEntryBase):
 
     self._export_subtextures(fullpath)
 
+  def _export_subatlas_manifest(self, subatlas, subtexture_path):
+    subatlas_manifest_path = os.path.splitext(subtexture_path)[0] + ".json"
+    with open(subatlas_manifest_path, 'w') as f:
+      json.dump(subatlas, f)
+
   @requires('PIL.Image')
   def _export_subtextures(self, target):
     # First, get the image out of the entry data
@@ -398,13 +403,13 @@ class TextureEntry(XNBAssetEntryBase):
       os.makedirs(os.path.join(target, subatlasdir), exist_ok=True)
       subtexture_path = get_unique_export_path(os.path.join(target, subatlasdir, f'{subatlasfile}.png'))
       subtexture.save(subtexture_path)
+      self._export_subatlas_manifest(subatlas, subtexture_path)
 
   def _get_original_image(self, image, original_size, top_left, scale_ratio):
     canvas_width = round(original_size['x']/scale_ratio['x'])
     canvas_height = round(original_size['y']/scale_ratio['y'])
     canvas = PIL.Image.new("RGBA", (canvas_width, canvas_height))
     canvas.paste(image, (top_left['x'], top_left['y']))
-    canvas.resize((original_size['x'], original_size['y']))
     return canvas
 
   def _extraction_path(self, target):

--- a/deppth2/texpacking.py
+++ b/deppth2/texpacking.py
@@ -71,6 +71,7 @@ def build_atlases_hades(source_dir, target_dir, deppth2_pack=True, include_hulls
     hulls = {}
     namemap = {}
     scaleRatioMap = {}
+    manifestHulls = {}
 
     temp_dir = tempfile.mkdtemp()
     temp_name_mapping = {}
@@ -87,6 +88,7 @@ def build_atlases_hades(source_dir, target_dir, deppth2_pack=True, include_hulls
         namemap[rel_path] = str(file_path)
 
         scaleRatioMap[rel_path] = get_scale_ratio(file_path)
+        manifestHulls[rel_path] = get_hull_from_manifest(file_path)
 
     # Create temporary images with unique names for PyTexturePacker to not override when creating the json file
     for rel_path, original_path in namemap.items():
@@ -120,7 +122,7 @@ def build_atlases_hades(source_dir, target_dir, deppth2_pack=True, include_hulls
         with open(f'{basename}{index}.json', 'w') as f:
             json.dump(original_data, f, indent=2)
 
-        atlases.append(transform_atlas(target_dir, basename, f'{basename}{index}.json', namemap, hulls, source_dir, manifest_paths, scaleRatioMap=scaleRatioMap))
+        atlases.append(transform_atlas(target_dir, basename, f'{basename}{index}.json', namemap, hulls, source_dir, manifest_paths, scaleRatioMap=scaleRatioMap, manifestHulls=manifestHulls))
         os.remove(f'{basename}{index}.json')
         index += 1
 
@@ -161,7 +163,15 @@ def get_scale_ratio(path):
         return image_manifest.get("scaleRatio", default_scale)
     return default_scale
 
-@requires('scipy.spatial')
+def get_hull_from_manifest(path):
+    default_hull = []
+    image_manifest_path = os.path.splitext(path)[0] + ".json"
+    if os.path.exists(image_manifest_path):
+        with open(image_manifest_path, 'r') as f:
+            image_manifest = json.load(f)
+        return image_manifest.get("hull", default_hull)
+    return default_hull
+
 def get_hull_points(path):
     try:
         import scipy.spatial
@@ -200,7 +210,7 @@ def find_files(source_dir):
         file_list.append(path)
     return file_list
 
-def transform_atlas(target_dir, basename, filename, namemap, hulls={}, source_dir='', manifest_paths=[], scaleRatioMap = {}):
+def transform_atlas(target_dir, basename, filename, namemap, hulls={}, source_dir='', manifest_paths=[], scaleRatioMap = {}, manifestHulls = []):
     with open(filename) as f:
         ptp_atlas = json.load(f)
         frames = ptp_atlas['frames']
@@ -231,6 +241,8 @@ def transform_atlas(target_dir, basename, filename, namemap, hulls={}, source_di
             subatlas['isMip'] = False
             subatlas['isAlpha8'] = False
             subatlas['hull'] = transform_hull(hulls.get(texture_name, []), subatlas['topLeft'], (subatlas['rect']['width'], subatlas['rect']['height']))
+            if len(subatlas['hull']) == 0:
+                subatlas['hull'] = manifestHulls.get(texture_name, [])
             atlas.subAtlases.append(subatlas)
 
     atlas.export_file(f'{os.path.splitext(filename)[0]}.atlas.json')

--- a/deppth2/texpacking.py
+++ b/deppth2/texpacking.py
@@ -158,7 +158,6 @@ def get_scale_ratio(path):
     if os.path.exists(image_manifest_path):
         with open(image_manifest_path, 'r') as f:
             image_manifest = json.load(f)
-        print(image_manifest)
         return image_manifest.get("scaleRatio", default_scale)
     return default_scale
 
@@ -215,7 +214,7 @@ def transform_atlas(target_dir, basename, filename, namemap, hulls={}, source_di
         for texture_name in frames:
             frame = frames[texture_name]
             subatlas = {}
-            subatlas['name'] = os.path.join(os.path.splitext(os.path.relpath(namemap[texture_name], source_dir))[0])
+            subatlas['name'] = os.path.join(basename, os.path.splitext(os.path.relpath(namemap[texture_name], source_dir))[0])
             manifest_paths.append(subatlas['name'])
             subatlas['topLeft'] = {'x': frame['spriteSourceSize']['x'], 'y': frame['spriteSourceSize']['y']}
             subatlas['scaleRatio'] = scaleRatioMap.get(texture_name, {'x': 1.0, 'y': 1.0 })

--- a/deppth2/texpacking.py
+++ b/deppth2/texpacking.py
@@ -70,6 +70,7 @@ def build_atlases_hades(source_dir, target_dir, deppth2_pack=True, include_hulls
     files = find_files(source_dir)
     hulls = {}
     namemap = {}
+    scaleRatioMap = {}
 
     temp_dir = tempfile.mkdtemp()
     temp_name_mapping = {}
@@ -84,6 +85,8 @@ def build_atlases_hades(source_dir, target_dir, deppth2_pack=True, include_hulls
         else:
             hulls[rel_path] = []
         namemap[rel_path] = str(file_path)
+
+        scaleRatioMap[rel_path] = get_scale_ratio(file_path)
 
     # Create temporary images with unique names for PyTexturePacker to not override when creating the json file
     for rel_path, original_path in namemap.items():
@@ -117,7 +120,7 @@ def build_atlases_hades(source_dir, target_dir, deppth2_pack=True, include_hulls
         with open(f'{basename}{index}.json', 'w') as f:
             json.dump(original_data, f, indent=2)
 
-        atlases.append(transform_atlas(target_dir, basename, f'{basename}{index}.json', namemap, hulls, source_dir, manifest_paths))
+        atlases.append(transform_atlas(target_dir, basename, f'{basename}{index}.json', namemap, hulls, source_dir, manifest_paths, scaleRatioMap=scaleRatioMap))
         os.remove(f'{basename}{index}.json')
         index += 1
 
@@ -148,6 +151,16 @@ def build_atlases_hades(source_dir, target_dir, deppth2_pack=True, include_hulls
         print(path_clean)
 
     shutil.rmtree(temp_dir)
+
+def get_scale_ratio(path):
+    default_scale = {"x":1.0, "y":1.0}
+    image_manifest_path = os.path.splitext(path)[0] + ".json"
+    if os.path.exists(image_manifest_path):
+        with open(image_manifest_path, 'r') as f:
+            image_manifest = json.load(f)
+        print(image_manifest)
+        return image_manifest.get("scaleRatio", default_scale)
+    return default_scale
 
 @requires('scipy.spatial')
 def get_hull_points(path):
@@ -188,7 +201,7 @@ def find_files(source_dir):
         file_list.append(path)
     return file_list
 
-def transform_atlas(target_dir, basename, filename, namemap, hulls={}, source_dir='', manifest_paths=[]):
+def transform_atlas(target_dir, basename, filename, namemap, hulls={}, source_dir='', manifest_paths=[], scaleRatioMap = {}):
     with open(filename) as f:
         ptp_atlas = json.load(f)
         frames = ptp_atlas['frames']
@@ -202,17 +215,19 @@ def transform_atlas(target_dir, basename, filename, namemap, hulls={}, source_di
         for texture_name in frames:
             frame = frames[texture_name]
             subatlas = {}
-            subatlas['name'] = os.path.join(basename, os.path.splitext(os.path.relpath(namemap[texture_name], source_dir))[0])
+            subatlas['name'] = os.path.join(os.path.splitext(os.path.relpath(namemap[texture_name], source_dir))[0])
             manifest_paths.append(subatlas['name'])
             subatlas['topLeft'] = {'x': frame['spriteSourceSize']['x'], 'y': frame['spriteSourceSize']['y']}
-            subatlas['originalSize'] = {'x': frame['sourceSize']['w'], 'y': frame['sourceSize']['h']}
+            subatlas['scaleRatio'] = scaleRatioMap.get(texture_name, {'x': 1.0, 'y': 1.0 })
+            subatlas['originalSize'] = {
+                'x': round(frame['sourceSize']['w'] * subatlas['scaleRatio']['x']), 
+                'y': round(frame['sourceSize']['h'] * subatlas['scaleRatio']['y'])}
             subatlas['rect'] = {
                 'x': frame['frame']['x'],
                 'y': frame['frame']['y'],
                 'width': frame['frame']['w'],
                 'height': frame['frame']['h']
             }
-            subatlas['scaleRatio'] = {'x': 1.0, 'y': 1.0}
             subatlas['isMulti'] = False
             subatlas['isMip'] = False
             subatlas['isAlpha8'] = False


### PR DESCRIPTION
The manifest generated for subtextures are used to inform the scaling and original size data while repacking