### PR TITLE
Skip extracting lower level mips during subtexture extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,18 @@ I can then distribute Launch_patch.pkg and Launch_patch.pkg_manifest. To apply t
 
 This will replace any entries in the package with any matching entries in the patches and append any new entries in the patches. More than one patch can be applied at a time (later ones take precedence if there are conflicts).
 
+To **extract** every subtexture instead of packed atlases use the `-s` or `--subtextures` flag.
+
+    deppth2 ex -s Launch.pkg
+
+This doesn't extract lower mip textures by default as they are irrelevant for most use cases. If you need to extract them you can use the `--include-mip` flag.
+
 ## Deppth2 API
 
 The Deppth2 module exposes functions that perform the actions described above, plus a fourth (which is also part of the CLI) to list the contents of a package. It's basically just a programmer interface for the same things the CLI does -- the latter is just a wrapper for the former.
 ```py
     list(name, *patterns, logger=lambda  s: None)
-    extract(package, target_dir, *entries, subtextures=False, logger=lambda  s: None)
+    extract(package, target_dir, *entries, subtextures=False, logger=lambda  s: None, include_mip=False)
     pack(source_dir, package, *entries, logger=lambda  s: None)
     patch(name, *patches, logger=lambda  s : None)
 ```

--- a/deppth2/cli.py
+++ b/deppth2/cli.py
@@ -22,6 +22,7 @@ def main():
     extract_parser.add_argument('-t', '--target', metavar='target', default='', help='Where to extract the package')
     extract_parser.add_argument('-e', '--entries', nargs='*', metavar='entry', help='One or more entry names to extract')
     extract_parser.add_argument('-s', '--subtextures', action='store_true', default=False, help='Export subtextures instead of full atlases')
+    extract_parser.add_argument('--include-mip', action='store_true', default=False, help='Include lower mip levels of textures if available. Only applicable for subtexture extraction')
     extract_parser.set_defaults(func=cli_extract)
 
     # Pack parser
@@ -67,8 +68,9 @@ def cli_extract(args):
     target = args.target
     entries = args.entries or []
     subtextures = args.subtextures
+    include_mip = args.include_mip
 
-    extract(source, target, *entries, subtextures=subtextures, logger=lambda s: print(s))
+    extract(source, target, *entries, subtextures=subtextures, logger=lambda s: print(s), include_mip=include_mip)
 
 def cli_pack(args):
     curdir = os.getcwd()

--- a/deppth2/deppth2.py
+++ b/deppth2/deppth2.py
@@ -25,11 +25,14 @@ def list_contents(name, *patterns, logger=lambda s: None):
           subname = subatlas['name']
           logger(f'  {subname}')
 
-def extract(package, target_dir, *entries, subtextures=False, logger=lambda s: None):
+def extract(package, target_dir, *entries, subtextures=False, logger=lambda s: None, include_mip=False):
   includes = []
 
   if len(target_dir) == 0:
     target_dir = os.path.splitext(package)[0]
+
+  if subtextures and not include_mip:
+    logger('Ignoring extraction of lower mip level sub textures.')
 
   os.makedirs(target_dir, exist_ok=True)
   with PackageWithManifestReader(package) as f:
@@ -46,7 +49,7 @@ def extract(package, target_dir, *entries, subtextures=False, logger=lambda s: N
       if subtextures and entry.manifest_entry is None:
         allow_subtextures = False
         logger(f'No atlas for subtextures found. Subtextures for this entry will not be extracted.')
-      entry.extract(target_dir, subtextures=allow_subtextures)
+      entry.extract(target_dir, subtextures=allow_subtextures, include_mip=include_mip)
 
     if not f.manifest is None:
       for entry in f.manifest.values():
@@ -54,7 +57,7 @@ def extract(package, target_dir, *entries, subtextures=False, logger=lambda s: N
           continue
 
         logger(f'Extracting manifest entry {entry.name}')
-        entry.extract(target_dir, subtextures=subtextures, includes=includes)
+        entry.extract(target_dir, subtextures=subtextures, includes=includes, include_mip=include_mip)
 
     if len(includes) > 0:
       include_dir = os.path.join(target_dir, 'manifest')

--- a/deppth2/entries.py
+++ b/deppth2/entries.py
@@ -247,7 +247,8 @@ class TextureEntry(XNBAssetEntryBase):
   """
   def extract(self, target, **kwargs):
     if 'subtextures' in kwargs and kwargs['subtextures']:
-      self._export_subtextures(os.path.join(target, 'textures'))
+      include_mip = kwargs.get("include_mip", False)
+      self._export_subtextures(os.path.join(target, 'textures'), include_mip)
     else:
       os.makedirs(os.path.join(target, 'textures', 'atlases'), exist_ok=True)
       self._export(self._extraction_path(target) + '.png')
@@ -381,12 +382,12 @@ class TextureEntry(XNBAssetEntryBase):
     self._export_subtextures(fullpath)
 
   @requires('PIL.Image')
-  def _export_subtextures(self, target):
+  def _export_subtextures(self, target, include_mip=False):
     # First, get the image out of the entry data
     image = self._get_image()
     atlas = self.manifest_entry
     for subatlas in atlas.subAtlases:
-      if not subatlas.get("isMip", False):
+      if not subatlas.get("isMip", False) or include_mip:
         rect = subatlas['rect']
         box = (
           rect['x'],

--- a/deppth2/entries.py
+++ b/deppth2/entries.py
@@ -386,18 +386,21 @@ class TextureEntry(XNBAssetEntryBase):
     image = self._get_image()
     atlas = self.manifest_entry
     for subatlas in atlas.subAtlases:
-      rect = subatlas['rect']
-      box = (rect['x'], 
-      rect['y'], 
-      rect['x']+rect['width'], 
-      rect['y']+rect['height'])
-      subimage = image.crop(box)
-      subtexture = self._get_original_image(subimage, subatlas['originalSize'], subatlas['topLeft'], subatlas['scaleRatio'])
-      subatlas_path = subatlas['name'].replace('\\', '/')
-      subatlasdir, subatlasfile = os.path.split(subatlas_path)
-      os.makedirs(os.path.join(target, subatlasdir), exist_ok=True)
-      subtexture_path = get_unique_export_path(os.path.join(target, subatlasdir, f'{subatlasfile}.png'))
-      subtexture.save(subtexture_path)
+      if not subatlas.get("isMip", False):
+        rect = subatlas['rect']
+        box = (
+          rect['x'],
+          rect['y'],
+          rect['x']+rect['width'],
+          rect['y']+rect['height']
+        )
+        subimage = image.crop(box)
+        subtexture = self._get_original_image(subimage, subatlas['originalSize'], subatlas['topLeft'], subatlas['scaleRatio'])
+        subatlas_path = subatlas['name'].replace('\\', '/')
+        subatlasdir, subatlasfile = os.path.split(subatlas_path)
+        os.makedirs(os.path.join(target, subatlasdir), exist_ok=True)
+        subtexture_path = get_unique_export_path(os.path.join(target, subatlasdir, f'{subatlasfile}.png'))
+        subtexture.save(subtexture_path)
 
   def _get_original_image(self, image, original_size, top_left, scale_ratio):
     canvas_width = round(original_size['x']/scale_ratio['x'])


### PR DESCRIPTION
With the way deppth2 is regularly used and its inability to package mip texture levels natively. I think its best we just disable their extraction too, giving a clean non-confusing output.